### PR TITLE
Add Trivia page with navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -55,6 +55,10 @@
 </head>
 
 <body class="size0">
+    <nav id="main-nav">
+        <a href="index.html" class="tab active">Card Generator</a>
+        <a href="trivia.html" class="tab">Trivia</a>
+    </nav>
     <table id="table">
         <colgroup>
             <col>

--- a/docs/style.css
+++ b/docs/style.css
@@ -716,3 +716,34 @@ button.delete-all:focus {
 #favorites-list li:hover {
     background: var(--color-background3);
 }
+
+#main-nav {
+    display: flex;
+    gap: 1em;
+    padding: 0.5em;
+    background: var(--color-background2);
+}
+
+#main-nav .tab {
+    text-decoration: none;
+    color: var(--color-link);
+    padding: 0.2em 0.5em;
+}
+
+#main-nav .tab.active {
+    font-weight: bold;
+    border-bottom: 2px solid var(--color-link-hover);
+}
+
+#trivia-container {
+    padding: 1em;
+}
+
+#trivia-container button {
+    margin-bottom: 1em;
+}
+
+#answers button {
+    display: block;
+    margin: 0.25em 0;
+}

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -8,7 +8,9 @@ const RUNTIME = 'runtime';
 const OFFLINE_URL = './';
 const PRECACHE_CORE_URLS = [
   'index.html',
+  'trivia.html',
   'main.js',
+  'trivia.js',
   'style.css',
   'fonts/font-title.css',
   'fonts/font-specials.css',

--- a/docs/trivia.html
+++ b/docs/trivia.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <title>Harry Potter Trivia</title>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js');
+        }
+    </script>
+</head>
+<body>
+    <nav id="main-nav">
+        <a href="index.html" class="tab">Card Generator</a>
+        <a href="trivia.html" class="tab active">Trivia</a>
+    </nav>
+    <main id="trivia-container">
+        <button id="next-question">Get Trivia Question</button>
+        <p id="question"></p>
+        <div id="answers"></div>
+    </main>
+    <script src="trivia.js"></script>
+</body>
+</html>

--- a/docs/trivia.js
+++ b/docs/trivia.js
@@ -1,0 +1,38 @@
+function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+}
+
+function loadQuestion() {
+    const qEl = document.getElementById('question');
+    const aEl = document.getElementById('answers');
+    qEl.textContent = 'Loading...';
+    aEl.innerHTML = '';
+    fetch('https://opentdb.com/api.php?amount=1&type=multiple')
+        .then(r => r.json())
+        .then(data => {
+            const q = data.results[0];
+            qEl.innerHTML = q.question;
+            const answers = shuffle([q.correct_answer, ...q.incorrect_answers]);
+            answers.forEach(ans => {
+                const btn = document.createElement('button');
+                btn.textContent = ans;
+                btn.onclick = () => {
+                    alert(ans === q.correct_answer ? 'Correct!' : 'Wrong!');
+                };
+                aEl.appendChild(btn);
+            });
+        })
+        .catch(err => {
+            qEl.textContent = 'Failed to load question.';
+            console.error(err);
+        });
+}
+
+document.getElementById('next-question').addEventListener('click', loadQuestion);
+
+// load first question on page load
+loadQuestion();


### PR DESCRIPTION
## Summary
- add navigation tabs to switch between pages
- create new Trivia page and script to fetch trivia questions
- style new navigation bar and trivia UI
- cache new files in service worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c193d01208320b3c2ec8d9cdd8516