### PR TITLE
Add overwrite prompt when saving favorites

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1448,6 +1448,17 @@ function Favorites(name) {
     };
     this.add = function (params) {
         this.refresh();
+        let newTitle = (getQueryParams(params).title || "").trim();
+        let existingIndex = data.findIndex(function (item) {
+            return (getQueryParams(item).title || "").trim() === newTitle;
+        });
+        if (existingIndex !== -1) {
+            let displayTitle = newTitle === "" ? "<unnamed card>" : newTitle;
+            if (!window.confirm("Would you like to overwrite the current " + displayTitle + " card?")) {
+                return;
+            }
+            data.splice(existingIndex, 1);
+        }
         data = data.remove(params);
         data.push(params);
         this.save();


### PR DESCRIPTION
## Summary
- prompt users before overwriting an existing favorite card with the same name

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687cedc43d988320ba347ab177b70f18