### PR TITLE
Add view parameter to hide card generator UI

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,6 +34,11 @@
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('sw.js');
         }
+
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('view') === 'card') {
+            document.documentElement.classList.add('view-card');
+        }
         
         function initialize() {
             initCardImageGenerator();

--- a/docs/style.css
+++ b/docs/style.css
@@ -762,3 +762,23 @@ button.delete-all:focus {
     height: 1200px;
     border: none;
 }
+html.view-card body:before,
+html.view-card body:after,
+html.view-card #main-nav,
+html.view-card #sizes,
+html.view-card #legend,
+html.view-card #download,
+html.view-card #reset,
+html.view-card #share,
+html.view-card #favorites,
+html.view-card #addFavorite,
+html.view-card #manage-favorites,
+html.view-card #openFontSettings,
+html.view-card #manage-fonts,
+html.view-card #table th:not(:first-child),
+html.view-card #table td {
+    display: none !important;
+}
+html.view-card body {
+    margin: 0;
+}

--- a/docs/trivia.js
+++ b/docs/trivia.js
@@ -14,7 +14,8 @@ function loadCard() {
         return;
     }
     const sel = triviaCards[Math.floor(Math.random() * triviaCards.length)];
-    frame.src = 'index.html' + sel;
+    const url = 'index.html' + sel + (sel.includes('?') ? '&' : '?') + 'view=card';
+    frame.src = url;
     frame.style.display = 'block';
     msg.textContent = '';
 }


### PR DESCRIPTION
## Summary
- detect `view=card` parameter in index.html
- hide all generator controls in view mode via CSS
- load `view=card` when showing trivia cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cf70e648c8320abdcae95204e7dc0