### PR TITLE
Add trivia card type

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -99,6 +99,10 @@
                     <label for="size5" style="margin-left:0.5em;">
                         <img src="card-resources/MatIcon.png" width="62" height="46" alt="" title="Player Mat" />
                     </label>
+                    <input type="radio" name="size" id="size6" value="6" />
+                    <label for="size6">
+                        <img src="card-resources/BaseCardIcon.png" width="46" height="30" alt="" title="Trivia" />
+                    </label>
                 </menu>
                 <ul id="legend">
                     <li><span class="def">-</span>: Horizontal Bar</li>
@@ -151,10 +155,10 @@
             <td class="doubledForDoubleCards">
                 <div>
                     <label for="title">Title</label>
-                    <input id="title" placeholder="Village" />
+                    <textarea id="title" rows="2" placeholder="Village"></textarea>
                 </div>
             </td>
-            <td>
+            <td class="hideForTrivia">
                 <div>
                     <label for="title2">Title</label>
                     <input id="title2" />
@@ -162,14 +166,14 @@
             </td>
         </tr>
         <tr>
-            <td class="doubledForDoubleCards hideForPileMarker">
+            <td class="doubledForDoubleCards hideForPileMarker hideForTrivia">
                 <div>
                     <label for="description">Description</label>
                     <textarea rows="5" id="description" placeholder="+1 Card
 +2 Actions"></textarea>
                 </div>
             </td>
-            <td class="hideForPileMarker hideForMats">
+            <td class="hideForPileMarker hideForMats hideForTrivia">
                 <div>
                     <label for="description2">Description</label>
                     <textarea rows="5" id="description2"></textarea>
@@ -177,13 +181,13 @@
             </td>
         </tr>
         <tr>
-            <td class="hideForPileMarker">
+            <td class="hideForPileMarker hideForTrivia">
                 <div>
                     <label for="boldkeys">Additional Bold Keywords</label>
                     <input id="boldkeys" placeholder="Additional boldable keywords; separated by semicolons" />
                 </div>
             </td>
-            <td class="hideForPileMarker">
+            <td class="hideForPileMarker hideForTrivia">
                 <div>
                     <label for="custom-icon">Custom Icon</label>
                     <input id="custom-icon" type="url" placeholder="http://example.com/icon.png" />
@@ -194,10 +198,10 @@
             </td>
         </tr>
         <tr>
-            <td class="hideForPileMarker hideForMats">
+            <td class="hideForPileMarker hideForMats hideForTrivia">
                 <div>
                     <label for="type">Type</label>
-                    <span class="type-checkboxes hideForBaseCards hideForPileMarker hideForMats hideForDoubleCard">
+            <span class="type-checkboxes hideForBaseCards hideForPileMarker hideForMats hideForDoubleCard hideForTrivia">
                         <span class="checkbox hideForLandscape">
                             <input id="traveller" type="checkbox" placeholder="Action">
                             <label for="traveller">Traveller</label>
@@ -210,7 +214,7 @@
                     <input id="type" placeholder="Action">
                 </div>
             </td>
-            <td class="hideForPileMarker hideForMats">
+            <td class="hideForPileMarker hideForMats hideForTrivia">
                 <div>
                     <label for="type2"></label>
                     <input id="type2" />
@@ -218,7 +222,7 @@
             </td>
         </tr>
         <tr>
-            <td rowspan="3" class="doubledForPileMarkers">
+            <td rowspan="3" class="doubledForPileMarkers hideForTrivia">
                 <div id="image-positioning">
                     <label for="picture">URL of Illustration</label>
                     <input id="picture" type="url" placeholder="http://example.com/image.jpg" />
@@ -248,7 +252,7 @@
                     </table>
                 </div>
             </td>
-            <td class="hideForPileMarker">
+            <td class="hideForPileMarker hideForTrivia">
                 <div>
                     <label for="expansion">URL of Expansion Icon</label>
                     <input id="expansion" type="url" placeholder="http://example.com/expansion.png" />
@@ -258,7 +262,7 @@
             </td>
         </tr>
         <tr>
-            <td class="hideForPileMarker">
+            <td class="hideForPileMarker hideForTrivia">
                 <div>
                     <label for="credit">Art Credit</label>
                     <input id="credit" type="text" placeholder="Illustration: Jane Doe" />
@@ -266,7 +270,7 @@
             </td>
         </tr>
         <tr>
-            <td class="hideForPileMarker">
+            <td class="hideForPileMarker hideForTrivia">
                 <div>
                     <label for="creator">Version &amp; Creator Credit</label>
                     <input id="creator" type="text" placeholder="v0.1 John Doe" />
@@ -274,12 +278,12 @@
             </td>
         </tr>
         <tr>
-            <td id="priceCell" class="hideForPileMarker hideForMats">
+            <td id="priceCell" class="hideForPileMarker hideForMats hideForTrivia">
                 <div>
                     <label for="price">Price</label>
                     <input id="price" placeholder="$3" />
             </td>
-            <td id="previewCell" class="hideForPileMarker hideForMats">
+            <td id="previewCell" class="hideForPileMarker hideForMats hideForTrivia">
                 <div>
                     <label for="preview"></label>
                     <input id="preview" />
@@ -287,7 +291,7 @@
             </td>
         </tr>
         <tr>
-            <td class="hideForMats doubledForBaseCards doubledForPileMarkers doubledForTraits">
+            <td class="hideForMats doubledForBaseCards doubledForPileMarkers doubledForTraits hideForTrivia">
                 <div>
                     <label for="normalcolor1">Color</label>
                     <select name="normalcolor" id="normalcolor1">
@@ -302,7 +306,7 @@
                     </div>
                 </div>
             </td>
-            <td class="hideForBaseCards hideForPileMarker hideForMats hideForTraits">
+            <td class="hideForBaseCards hideForPileMarker hideForMats hideForTraits hideForTrivia">
                 <div>
                     <label for="normalcolor2">Color</label>
                     <span id="color-switch"><button id="color-switch-button" alt="Switch Colors"><img src="assets/icon-switch.png" />Switch</button></span>

--- a/docs/main.js
+++ b/docs/main.js
@@ -507,7 +507,7 @@ function initCardImageGenerator() {
         var context;
         if (templateSize === 0 || templateSize === 2 || templateSize === 3) {
             context = canvases[0].getContext("2d");
-        } else if (templateSize === 1 || templateSize === 4) {
+        } else if (templateSize === 1 || templateSize === 4 || templateSize === 6) {
             context = canvases[1].getContext("2d");
         } else {
             context = canvases[2].getContext("2d");
@@ -888,6 +888,21 @@ function initCardImageGenerator() {
             writeCreatorCredit(913, 660, "white", "", 16);
 
             drawExpansionIcon(888, 40, 40, 40);
+
+        } else if (templateSize == 6) { // trivia card
+            removeCorners(2151, 1403, 100);
+            context.drawImage(getRecoloredImage(6, 0), 0, 0);
+            if (normalColorCurrentIndices[1] > 0)
+                context.drawImage(getRecoloredImage(7, 1), 0, 0);
+            context.drawImage(getRecoloredImage(8, 0, 6), 0, 0);
+            context.drawImage(getRecoloredImage(15, 0, 9), 0, 0);
+
+            context.textAlign = "center";
+            context.textBaseline = "middle";
+
+            if (isEachColorDark[1])
+                context.fillStyle = "white";
+            writeDescription("title", 1075, 702, 1800, 600, 70);
 
         }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -142,7 +142,8 @@ a:focus {
 
 body.size1 #load-indicator,
 body.size4 #load-indicator,
-body.size5 #load-indicator {
+body.size5 #load-indicator,
+body.size6 #load-indicator {
     top: 160px;
     left: 235px;
 }
@@ -174,6 +175,7 @@ body:not(.size5) .myCanvas {
 body.size1 #portraitCanvas,
 body.size4 #portraitCanvas,
 body.size5 #portraitCanvas,
+body.size6 #portraitCanvas,
 body.size0 #landscapeCanvas,
 body.size2 #landscapeCanvas,
 body.size3 #landscapeCanvas,
@@ -182,7 +184,8 @@ body.size0 #matCanvas,
 body.size1 #matCanvas,
 body.size2 #matCanvas,
 body.size3 #matCanvas,
-body.size4 #matCanvas {
+body.size4 #matCanvas,
+body.size6 #matCanvas {
     display: none;
 }
 
@@ -198,7 +201,8 @@ body.size4 #matCanvas {
 
 body.size1 #sizes,
 body.size4 #sizes,
-body.size5 #sizes {
+body.size5 #sizes,
+body.size6 #sizes {
     top: calc(490px - 80px);
 }
 
@@ -299,30 +303,36 @@ button:active {
 body.size1 #download,
 body.size4 #download,
 body.size5 #download,
+body.size6 #download,
 body.size1 #reset,
 body.size4 #reset,
-body.size5 #reset {
+body.size5 #reset,
+body.size6 #reset {
     top: calc(795px - 80px);
 }
 
 body.size1 #openFontSettings,
 body.size4 #openFontSettings,
 body.size5 #openFontSettings,
+body.size6 #openFontSettings,
 body.size1 #favorites,
 body.size4 #favorites,
-body.size5 #favorites {
+body.size5 #favorites,
+body.size6 #favorites {
     top: calc(795px - 80px + 3em);
 }
 
 body.size1 #addFavorite,
 body.size4 #addFavorite,
-body.size5 #addFavorite {
+body.size5 #addFavorite,
+body.size6 #addFavorite {
     top: calc(795px - 80px + 6em);
 }
 
 body.size1 #share,
 body.size4 #share,
-body.size5 #share {
+body.size5 #share,
+body.size6 #share {
     top: calc(795px - 80px + 6em);
 }
 
@@ -381,7 +391,8 @@ col {
 
 body.size1 col,
 body.size4 col,
-body.size5 col {
+body.size5 col,
+body.size6 col {
     width: 483px;
 }
 
@@ -416,6 +427,7 @@ body.size2 .hideForDoubleCard,
 body.size3 .hideForBaseCards,
 body.size4 .hideForPileMarker,
 body.size5 .hideForMats,
+body.size6 .hideForTrivia,
 body.size1.trait .hideForTraits {
     visibility: collapse;
     display: none !important;
@@ -471,6 +483,15 @@ label {
 
 textarea {
     resize: vertical;
+}
+
+body:not(.size6) #title {
+    height: 1.4em;
+    resize: none;
+}
+
+body.size6 #title {
+    height: 7em;
 }
 
 input[type=number] {
@@ -559,7 +580,8 @@ label[for="type"] {
 
 body.size1 [data-status]:after,
 body.size4 [data-status]:after,
-body.size5 [data-status]:after {
+body.size5 [data-status]:after,
+body.size6 [data-status]:after {
     top: calc(492px - 80px);
 }
 
@@ -574,7 +596,8 @@ body.size5 [data-status]:after {
 
 body.size1 #legend,
 body.size4 #legend,
-body.size5 #legend {
+body.size5 #legend,
+body.size6 #legend {
     top: calc(540px - 80px);
 }
 


### PR DESCRIPTION
## Summary
- add new size option for trivia cards
- support multiline titles via textarea
- draw Trivia cards with landscape canvas and no picture
- hide irrelevant inputs when trivia size is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cfc9b0f288320b97c6d2b3712d307