### PR TITLE
Add CSV import support for favorites

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ If you want to host the generator yourself, please also run your own version of 
 ```
 https://dominion-card-generator-cors.herokuapp.com/
 ```
+
+### Favorites Import Format
+The generator allows saving favorite cards in your browser. The favorites menu
+now supports importing files in two formats:
+
+1. A JSON array exported from the generator.
+2. A simple CSV file where each line contains a card link.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,7 +119,7 @@
                         <button type="button" class="delete-all hidden" onclick="myFavorites.deleteAll()"><img src="assets/icon-delete.png" />Delete All</button>
                         <button type="button" class="sort" onclick="myFavorites.sort()" title="Sort"><img alt="Sort" src="assets/icon-sort.png" /></button>
                         <button type="button" class="" onclick="myFavorites.export()" title="Export"><img alt="Export" src="assets/icon-download.png" /></button>
-                        <button type="button" class="" onclick="myFavorites.import()" title="Import"><img alt="Import" src="assets/icon-upload.png" /></button>
+                        <button type="button" class="" onclick="myFavorites.import()" title="Import JSON or CSV"><img alt="Import" src="assets/icon-upload.png" /></button>
                         <button type="button" class="close" onclick="myFavorites.close()" title="Close"><img alt="Close" src="assets/icon-close.png" /></button>
                         <input id="favorites-search" type="search" class="search" placeholder="Search..." oninput="myFavorites.search(this.value)" />
                     </div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1418,7 +1418,16 @@ function Favorites(name) {
             reader.readAsText(file, 'UTF-8');
             reader.onload = readerEvent => {
                 let content = readerEvent.target.result;
-                let newData = JSON.parse(content);
+                let newData;
+                try {
+                    newData = JSON.parse(content);
+                    if (!Array.isArray(newData)) {
+                        newData = [];
+                    }
+                } catch (err) {
+                    // fall back to CSV where each line is a favorite link
+                    newData = content.split(/\r?\n/).filter(l => l.trim() !== "");
+                }
                 data = data.concat(newData);
                 myFavs.save();
 


### PR DESCRIPTION
## Summary
- allow importing favorites from newline-separated CSV files in addition to JSON
- clarify import button text
- document the new favorites import format in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cfeb027b88320a3d4cc9258e3a610