### PR TITLE
Set light grey page background

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -2,7 +2,7 @@
 :root {
 
     --color-text: black;
-    --color-background1: white;
+    --color-background1: #f0f0f0;
     --color-background2: #CCC;
     --color-background3: rgba(255, 255, 255, 0.5);
     --color-background4: #DDD;


### PR DESCRIPTION
## Summary
- tweak the root color scheme to use light grey as the default background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d0c9304f0832089814d0367f29e14