### PR TITLE
Move favorites to own tab

### DIFF
--- a/docs/favorites.html
+++ b/docs/favorites.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <title>Favorites</title>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js');
+        }
+    </script>
+</head>
+<body>
+    <nav id="main-nav">
+        <a href="index.html" class="tab">Card Generator</a>
+        <a href="trivia.html" class="tab">Trivia</a>
+        <a href="favorites.html" class="tab active">Favorites</a>
+    </nav>
+    <div id="manage-favorites" class="popup">
+        <div class="menu">
+            <button type="button" class="delete-all hidden" onclick="myFavorites.deleteAll()"><img src="assets/icon-delete.png" />Delete All</button>
+            <button type="button" class="sort" onclick="myFavorites.sort()" title="Sort"><img alt="Sort" src="assets/icon-sort.png" /></button>
+            <button type="button" onclick="myFavorites.export()" title="Export"><img alt="Export" src="assets/icon-download.png" /></button>
+            <button type="button" onclick="myFavorites.import()" title="Import JSON or CSV"><img alt="Import" src="assets/icon-upload.png" /></button>
+            <input id="favorites-search" type="search" class="search" placeholder="Search..." oninput="myFavorites.search(this.value)" />
+        </div>
+        <ul id="favorites-list" class="popup-content"></ul>
+    </div>
+    <script src="main.js"></script>
+    <script>
+        let myFavorites;
+        window.addEventListener('DOMContentLoaded', () => {
+            myFavorites = new Favorites('myFavorites');
+            myFavorites.refresh();
+        });
+    </script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,6 +63,7 @@
     <nav id="main-nav">
         <a href="index.html" class="tab active">Card Generator</a>
         <a href="trivia.html" class="tab">Trivia</a>
+        <a href="favorites.html" class="tab">Favorites</a>
     </nav>
     <table id="table">
         <colgroup>
@@ -115,12 +116,10 @@
                         document.write('<a id="share" rel="nofollow" href="#share" onclick="if(navigator.vibrate){navigator.vibrate(50);};navigator.share({ title: document.title, text: document.title, url: window.location.href, }).catch((error) => console.log(\'Error sharing\', error));" title="Share Link"><button type="button"><img src="assets/icon-share.png" /></button></a>');
                     }
                 </script>
-                <a id="favorites" title="click to open saved cards"><button type="button" onclick="myFavorites.open()"><img src="assets/icon-favorites.png" />Favorites</button></a>
                 <a id="addFavorite" title="click to add current card to favorites"><button type="button" onclick="myFavorites.add( document.location.search )"><img src="assets/icon-favorites.png" />Add to Favorites</button></a>
                 <a id="deleteFavorite" title="click to remove current card from favorites"><button type="button" onclick="myFavorites.deleteByName( document.getElementById('title').value )"><img src="assets/icon-delete.png" />Delete from Favorites</button></a>
                 <div id="manage-favorites" class="popup hidden">
                     <div class="menu">
-                        <button type="button" onclick="myFavorites.add( document.location.search )"><img src="assets/icon-favorites.png" />Add Current Card</button>
                         <button type="button" class="delete-all hidden" onclick="myFavorites.deleteAll()"><img src="assets/icon-delete.png" />Delete All</button>
                         <button type="button" class="sort" onclick="myFavorites.sort()" title="Sort"><img alt="Sort" src="assets/icon-sort.png" /></button>
                         <button type="button" class="" onclick="myFavorites.export()" title="Export"><img alt="Export" src="assets/icon-download.png" /></button>

--- a/docs/trivia.html
+++ b/docs/trivia.html
@@ -14,6 +14,7 @@
     <nav id="main-nav">
         <a href="index.html" class="tab">Card Generator</a>
         <a href="trivia.html" class="tab active">Trivia</a>
+        <a href="favorites.html" class="tab">Favorites</a>
     </nav>
     <main id="trivia-container">
         <button id="next-card">Get Trivia Card</button>


### PR DESCRIPTION
## Summary
- add new **Favorites** tab linking to new `favorites.html`
- remove button that opened the favorites popup on the card generator
- drop the `Add Current Card` button from the favorites menu
- update navigation on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d605f00dc8320b6efe906a844ec45