### PR TITLE
Add edit card button to trivia tab

### DIFF
--- a/docs/trivia.html
+++ b/docs/trivia.html
@@ -18,6 +18,7 @@
     </nav>
     <main id="trivia-container">
         <button id="next-card">Get Trivia Card</button>
+        <button id="edit-card" class="hidden">Edit Card</button>
         <p id="message"></p>
         <iframe id="card-frame" title="Trivia Card"></iframe>
     </main>

--- a/docs/trivia.js
+++ b/docs/trivia.js
@@ -1,6 +1,9 @@
+let currentCard = '';
+
 function loadCard() {
     const frame = document.getElementById('card-frame');
     const msg = document.getElementById('message');
+    const editBtn = document.getElementById('edit-card');
     const favorites = JSON.parse(localStorage.getItem('favorites') || '[]');
     const triviaCards = favorites.filter(q => {
         const query = q.startsWith('?') ? q.substring(1) : q;
@@ -11,16 +14,25 @@ function loadCard() {
     if (triviaCards.length === 0) {
         msg.textContent = 'No trivia cards in favorites.';
         frame.style.display = 'none';
+        editBtn.classList.add('hidden');
         return;
     }
     const sel = triviaCards[Math.floor(Math.random() * triviaCards.length)];
+    currentCard = sel;
     const url = 'index.html' + sel + (sel.includes('?') ? '&' : '?') + 'view=card';
     frame.src = url;
     frame.style.display = 'block';
+    editBtn.classList.remove('hidden');
     msg.textContent = '';
 }
 
 document.getElementById('next-card').addEventListener('click', loadCard);
+
+document.getElementById('edit-card').addEventListener('click', () => {
+    if (currentCard) {
+        window.location.href = 'index.html' + currentCard;
+    }
+});
 
 // load a card on page load
 window.addEventListener('DOMContentLoaded', loadCard);


### PR DESCRIPTION
## Summary
- add new Edit Card button on the trivia page
- hook button to open the selected card in the Card Generator
- hide the edit button if no trivia card is available

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d6888b92c832083d612fe4921fbbb