### PR TITLE
Fix favorites tab layout and navigation

### DIFF
--- a/docs/favorites.html
+++ b/docs/favorites.html
@@ -10,13 +10,13 @@
         }
     </script>
 </head>
-<body>
+<body class="favorites-page">
     <nav id="main-nav">
         <a href="index.html" class="tab">Card Generator</a>
         <a href="trivia.html" class="tab">Trivia</a>
         <a href="favorites.html" class="tab active">Favorites</a>
     </nav>
-    <div id="manage-favorites" class="popup">
+    <div id="manage-favorites">
         <div class="menu">
             <button type="button" class="delete-all hidden" onclick="myFavorites.deleteAll()"><img src="assets/icon-delete.png" />Delete All</button>
             <button type="button" class="sort" onclick="myFavorites.sort()" title="Sort"><img alt="Sort" src="assets/icon-sort.png" /></button>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1592,7 +1592,7 @@ function Favorites(name) {
 
             let li = document.createElement("li");
             let a = document.createElement("a");
-            a.setAttribute('href', location.pathname + item);
+            a.setAttribute('href', 'index.html' + item);
             a.appendChild(document.createTextNode(title));
             if (item === document.location.search) {
                 li.setAttribute('class', "active");

--- a/docs/style.css
+++ b/docs/style.css
@@ -823,3 +823,26 @@ html.view-card body {
     margin: 0;
     background: white;
 }
+
+/* Layout adjustments for standalone favorites page */
+body.favorites-page #manage-favorites {
+    position: static;
+    top: auto;
+    left: auto;
+    width: 100%;
+    height: auto;
+    box-shadow: none;
+    padding: 0;
+    background: var(--color-background2);
+}
+
+body.favorites-page #manage-favorites .menu {
+    position: static;
+    width: 100%;
+    padding: 1em;
+    background: var(--color-background2);
+}
+
+body.favorites-page #favorites-list {
+    margin-top: 1em;
+}


### PR DESCRIPTION
## Summary
- show favorites page in full screen instead of floating popup
- wire favorites links to open cards in the card generator

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d6864d714832083f5ace2f07bb6f7