### PR TITLE
Change trivia layout

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -630,7 +630,8 @@ function initCardImageGenerator() {
             }
             if (isEachColorDark[1])
                 context.fillStyle = "white";
-            writeSingleLine(document.getElementById("title").value, 701, 215, previewLine ? 800 : 1180, 75);
+            if (!isTrivia)
+                writeSingleLine(document.getElementById("title").value, 701, 215, previewLine ? 800 : 1180, 75);
             if (typeLine.split(" - ").length >= 4) {
                 let types2 = typeLine.split(" - ");
                 let types1 = types2.splice(0, Math.ceil(types2.length / 2));
@@ -658,7 +659,7 @@ function initCardImageGenerator() {
             context.fillStyle = (isEachColorDark[0]) ? "white" : "black";
             var desc0 = document.getElementById("description").value;
             if (isTrivia)
-                desc0 = desc0 + (desc0.trim() ? "\n-\n" : "") + document.getElementById("title").value;
+                desc0 = document.getElementById("title").value + (desc0.trim() ? "\n-\n" : "") + desc0;
             if (!heirloomLine)
                 writeDescription(desc0, 701, 1500, 960, 660, 64);
             else
@@ -710,19 +711,22 @@ function initCardImageGenerator() {
                     writeSingleLine(typeLine, 1075, 165, 780, 70);
                 }
 
-                context.save();
-                context.rotate(Math.PI * 3 / 2);
-                writeSingleLine(document.getElementById("title").value, -700, 2030, 750, 70);
-                context.restore();
-                context.save();
-                context.rotate(Math.PI / 2);
-                writeSingleLine(document.getElementById("title").value, 700, -120, 750, 70);
-                context.restore();
+                if (!isTrivia) {
+                    context.save();
+                    context.rotate(Math.PI * 3 / 2);
+                    writeSingleLine(document.getElementById("title").value, -700, 2030, 750, 70);
+                    context.restore();
+                    context.save();
+                    context.rotate(Math.PI / 2);
+                    writeSingleLine(document.getElementById("title").value, 700, -120, 750, 70);
+                    context.restore();
+                }
 
 
             } else {
 
-                writeSingleLine(document.getElementById("title").value, 1075, 165, 780, 70);
+                if (!isTrivia)
+                    writeSingleLine(document.getElementById("title").value, 1075, 165, 780, 70);
 
                 if (typeLine) {
                     context.save();
@@ -739,7 +743,7 @@ function initCardImageGenerator() {
                 writeLineWithIconsReplacedWithSpaces(priceLine + " ", 130, 205, 85 / 90, "mySpecials"); //adding a space confuses writeLineWithIconsReplacedWithSpaces into thinking this isn't a line that needs resizing
             var desc1 = document.getElementById("description").value;
             if (isTrivia)
-                desc1 = desc1 + (desc1.trim() ? "\n-\n" : "") + document.getElementById("title").value;
+                desc1 = document.getElementById("title").value + (desc1.trim() ? "\n-\n" : "") + desc1;
             writeDescription(desc1, 1075, 1107, 1600, 283, 70);
             writeIllustrationCredit(181, 1272, "black", "bold ");
             writeCreatorCredit(1969, 1272, "black", "bold ");
@@ -774,20 +778,22 @@ function initCardImageGenerator() {
                 else
                     recolorFactors = normalColorFactorLists[normalColorCurrentIndices[colorID] - colorID][1];
 
-                context.save();
-                var title = document.getElementById(l).value;
-                var size = 75 + 2;
-                do {
-                    context.font = (size -= 2) + "pt myTitle";
-                } while (context.measureText(title).width > 750);
-                context.textAlign = "left";
-                context.fillStyle = "rgb(" + Math.round(recolorFactors[0] * 224) + "," + Math.round(recolorFactors[1] * 224) + "," + Math.round(recolorFactors[2] * 224) + ")";
-                context.lineWidth = 15;
-                if (isEachColorDark[colorID])
-                    context.strokeStyle = "white";
-                context.strokeText(title, 150, 1287);
-                context.fillText(title, 150, 1287);
-                context.restore();
+                if (!isTrivia) {
+                    context.save();
+                    var title = document.getElementById(l).value;
+                    var size = 75 + 2;
+                    do {
+                        context.font = (size -= 2) + "pt myTitle";
+                    } while (context.measureText(title).width > 750);
+                    context.textAlign = "left";
+                    context.fillStyle = "rgb(" + Math.round(recolorFactors[0] * 224) + "," + Math.round(recolorFactors[1] * 224) + "," + Math.round(recolorFactors[2] * 224) + ")";
+                    context.lineWidth = 15;
+                    if (isEachColorDark[colorID])
+                        context.strokeStyle = "white";
+                    context.strokeText(title, 150, 1287);
+                    context.fillText(title, 150, 1287);
+                    context.restore();
+                }
 
                 if (isEachColorDark[colorID])
                     context.fillStyle = "white";
@@ -796,7 +802,7 @@ function initCardImageGenerator() {
                     writeLineWithIconsReplacedWithSpaces(p + " ", 153, 1940, 85 / 90, "mySpecials");
                 var descHalf = document.getElementById(d).value;
                 if (isTrivia)
-                    descHalf = descHalf + (descHalf.trim() ? "\n-\n" : "") + document.getElementById(l).value;
+                    descHalf = document.getElementById(l).value + (descHalf.trim() ? "\n-\n" : "") + descHalf;
                 writeDescription(descHalf, 701, 1600, 960, 460, 64);
                 context.restore();
             }
@@ -831,7 +837,8 @@ function initCardImageGenerator() {
             }
             if (isEachColorDark[1])
                 context.fillStyle = "white";
-            writeSingleLine(document.getElementById("title").value, 701, 215, previewLine ? 800 : 1180, 75);
+            if (!isTrivia)
+                writeSingleLine(document.getElementById("title").value, 701, 215, previewLine ? 800 : 1180, 75);
             if (typeLine.split(" - ").length >= 4) {
                 let types2 = typeLine.split(" - ");
                 let types1 = types2.splice(0, Math.ceil(types2.length / 2));
@@ -853,7 +860,7 @@ function initCardImageGenerator() {
             context.fillStyle = (isEachColorDark[0]) ? "white" : "black";
             var desc3 = document.getElementById("description").value;
             if (isTrivia)
-                desc3 = desc3 + (desc3.trim() ? "\n-\n" : "") + document.getElementById("title").value;
+                desc3 = document.getElementById("title").value + (desc3.trim() ? "\n-\n" : "") + desc3;
             if (!heirloomLine)
                 writeDescription(desc3, 701, 1060, 960, 1500, 64);
             else
@@ -872,18 +879,20 @@ function initCardImageGenerator() {
             context.textAlign = "center";
             context.textBaseline = "middle";
 
-            context.save();
-            if (isEachColorDark[1])
-                context.fillStyle = "white";
-            context.rotate(Math.PI / 2);
-            writeSingleLine(document.getElementById("title").value, 700, -1920, 500, 75);
-            context.restore();
-            context.save();
-            if (isEachColorDark[1])
-                context.fillStyle = "white";
-            context.rotate(Math.PI * 3 / 2);
-            writeSingleLine(document.getElementById("title").value, -700, 230, 500, 75);
-            context.restore();
+            if (!isTrivia) {
+                context.save();
+                if (isEachColorDark[1])
+                    context.fillStyle = "white";
+                context.rotate(Math.PI / 2);
+                writeSingleLine(document.getElementById("title").value, 700, -1920, 500, 75);
+                context.restore();
+                context.save();
+                if (isEachColorDark[1])
+                    context.fillStyle = "white";
+                context.rotate(Math.PI * 3 / 2);
+                writeSingleLine(document.getElementById("title").value, -700, 230, 500, 75);
+                context.restore();
+            }
         } else if (templateSize == 5) { //player mat
             drawPicture(464, 342, 928, 684);
 
@@ -897,11 +906,12 @@ function initCardImageGenerator() {
 
             if (isEachColorDark[1])
                 context.fillStyle = "white";
-            writeSingleLine(document.getElementById("title").value, 464, 96, 490, 55);
+            if (!isTrivia)
+                writeSingleLine(document.getElementById("title").value, 464, 96, 490, 55);
 
             var desc5 = document.getElementById("description").value;
             if (isTrivia)
-                desc5 = desc5 + (desc5.trim() ? "\n-\n" : "") + document.getElementById("title").value;
+                desc5 = document.getElementById("title").value + (desc5.trim() ? "\n-\n" : "") + desc5;
             writeDescription(desc5, 464, 572, 740, 80, 44);
 
             writeIllustrationCredit(15, 660, "white", "", 16);
@@ -925,7 +935,7 @@ function initCardImageGenerator() {
             var desc6 = document.getElementById("description");
             var text6 = desc6 ? desc6.value.trim() : "";
             if (text6.length > 0)
-                text6 = text6 + "\n-\n" + document.getElementById("title").value;
+                text6 = document.getElementById("title").value + "\n-\n" + text6;
             else
                 text6 = document.getElementById("title").value;
             writeDescription(text6, 1075, 702, 1800, 600, 70);


### PR DESCRIPTION
## Summary
- reconfigure trivia cards so the title comes above the description
- hide the normal title location for trivia types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d70c85e08832090541e48b698c6ef