### PR TITLE
Add editable favorites and edit button

### DIFF
--- a/docs/favorites.html
+++ b/docs/favorites.html
@@ -35,6 +35,7 @@
                     <th data-col="type2">Secondary Type</th>
                     <th data-col="version">Version #</th>
                     <th></th>
+                    <th></th>
                 </tr>
                 <tr class="filters">
                     <th><input data-filter="title" type="search" /></th>
@@ -44,6 +45,7 @@
                     <th><input data-filter="preview" type="search" /></th>
                     <th><input data-filter="type2" type="search" /></th>
                     <th><input data-filter="version" type="search" /></th>
+                    <th></th>
                     <th></th>
                 </tr>
             </thead>

--- a/docs/style.css
+++ b/docs/style.css
@@ -703,6 +703,15 @@ button.delete {
     margin-bottom: 0.15em;
 }
 
+button.edit {
+    float: right;
+    padding-top: 0.3em;
+    padding-bottom: 0.3em;
+    margin-top: 0.15em;
+    margin-bottom: 0.15em;
+    margin-right: 0.5em;
+}
+
 button.delete:hover,
 button.delete:focus,
 button.delete-all:hover,


### PR DESCRIPTION
## Summary
- allow editing values directly in favorites table
- add separate `Edit` button for opening the generator
- adjust favorites markup for edit column
- style new edit button

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d70ea52c4832087d78ab5f7744a31