### PR TITLE
Remove search and sort controls from favorites page

### DIFF
--- a/docs/favorites.html
+++ b/docs/favorites.html
@@ -19,10 +19,8 @@
     <div id="manage-favorites">
         <div class="menu">
             <button type="button" class="delete-all hidden" onclick="myFavorites.deleteAll()"><img src="assets/icon-delete.png" />Delete All</button>
-            <button type="button" class="sort" onclick="myFavorites.sort()" title="Sort"><img alt="Sort" src="assets/icon-sort.png" /></button>
             <button type="button" onclick="myFavorites.export()" title="Export"><img alt="Export" src="assets/icon-download.png" /></button>
             <button type="button" onclick="myFavorites.import()" title="Import JSON or CSV"><img alt="Import" src="assets/icon-upload.png" /></button>
-            <input id="favorites-search" type="search" class="search" placeholder="Search..." oninput="myFavorites.search(this.value)" />
         </div>
         <table id="favorites-table" class="popup-content">
             <thead>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1556,7 +1556,10 @@ function Favorites(name) {
     this.open = function () {
         this.refresh();
         fav.classList.remove('hidden');
-        document.getElementById('favorites-search').focus();
+        const searchInput = document.getElementById('favorites-search');
+        if (searchInput) {
+            searchInput.focus();
+        }
     };
     this.close = function () {
         fav.classList.add('hidden');


### PR DESCRIPTION
## Summary
- remove unused favorites search bar and sort button from `favorites.html`
- guard against missing search bar in `Favorites.open`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d84ab32788320946f1cfc539df1ca