### PR TITLE
Add dropdown for advanced card options

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,23 +181,6 @@
             </td>
         </tr>
         <tr>
-            <td class="hideForPileMarker hideForTrivia">
-                <div>
-                    <label for="boldkeys">Additional Bold Keywords</label>
-                    <input id="boldkeys" placeholder="Additional boldable keywords; separated by semicolons" />
-                </div>
-            </td>
-            <td class="hideForPileMarker hideForTrivia">
-                <div>
-                    <label for="custom-icon">Custom Icon</label>
-                    <input id="custom-icon" type="url" placeholder="http://example.com/icon.png" />
-                    <label class="image-upload" title="Use Local Image File"><img src="assets/icon-upload-image.png" alt="Upload" />
-                        <input id="custom-icon-upload" type="file" accept="image/*" /></label>
-
-                </div>
-            </td>
-        </tr>
-        <tr>
             <td class="hideForPileMarker hideForMats hideForTrivia">
                 <div>
                     <label for="type">Type</label>
@@ -221,73 +204,126 @@
                 </div>
             </td>
         </tr>
-        <tr>
-            <td rowspan="3" class="doubledForPileMarkers hideForTrivia">
-                <div id="image-positioning">
-                    <label for="picture">URL of Illustration</label>
-                    <input id="picture" type="url" placeholder="http://example.com/image.jpg" />
-                    <label class="image-upload" title="Use Local Image File"><img src="assets/icon-upload-image.png" alt="Upload" />
-                        <input id="picture-upload" type="file" accept="image/*" /></label>
+        <tr id="additional-options">
+            <td colspan="2">
+                <details>
+                    <summary>Additional Options</summary>
                     <table>
                         <tr>
-                            <td><label for="picture-x">Position X:</label></td>
-                            <td colspan="2"><input id="picture-x" type="range" min="-1" max="1" value="0" step="0.01"></td>
+                            <td class="hideForPileMarker hideForTrivia">
+                                <div>
+                                    <label for="boldkeys">Additional Bold Keywords</label>
+                                    <input id="boldkeys" placeholder="Additional boldable keywords; separated by semicolons" />
+                                </div>
+                            </td>
+                            <td class="hideForPileMarker hideForTrivia">
+                                <div>
+                                    <label for="custom-icon">Custom Icon</label>
+                                    <input id="custom-icon" type="url" placeholder="http://example.com/icon.png" />
+                                    <label class="image-upload" title="Use Local Image File"><img src="assets/icon-upload-image.png" alt="Upload" />
+                                        <input id="custom-icon-upload" type="file" accept="image/*" /></label>
+
+                                </div>
+                            </td>
                         </tr>
                         <tr>
-                            <td><label for="picture-y">Position Y:</label></td>
-                            <td colspan="2"><input id="picture-y" type="range" min="-1" max="1" value="0" step="0.01"></td>
+                            <td rowspan="3" class="doubledForPileMarkers hideForTrivia">
+                                <div id="image-positioning">
+                                    <label for="picture">URL of Illustration</label>
+                                    <input id="picture" type="url" placeholder="http://example.com/image.jpg" />
+                                    <label class="image-upload" title="Use Local Image File"><img src="assets/icon-upload-image.png" alt="Upload" />
+                                        <input id="picture-upload" type="file" accept="image/*" /></label>
+                                    <table>
+                                        <tr>
+                                            <td><label for="picture-x">Position X:</label></td>
+                                            <td colspan="2"><input id="picture-x" type="range" min="-1" max="1" value="0" step="0.01"></td>
+                                        </tr>
+                                        <tr>
+                                            <td><label for="picture-y">Position Y:</label></td>
+                                            <td colspan="2"><input id="picture-y" type="range" min="-1" max="1" value="0" step="0.01"></td>
+                                        </tr>
+                                        <tr>
+                                            <td><label for="picture-zoom">Zoom:</label></td>
+                                            <td colspan="2"><input id="picture-zoom" type="range" min="0" max="3" value="1" step="0.1"></td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="3"><button onclick="(function(){
+                                                     document.getElementById('picture-x').value=0;
+                                                     document.getElementById('picture-y').value=0;
+                                                     let z = document.getElementById('picture-zoom');z.value=1;
+                                                     z.onchange();})();">Reset Position</button>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </td>
+                            <td class="hideForPileMarker hideForTrivia">
+                                <div>
+                                    <label for="expansion">URL of Expansion Icon</label>
+                                    <input id="expansion" type="url" placeholder="http://example.com/expansion.png" />
+                                    <label class="image-upload" title="Use Local Image File"><img src="assets/icon-upload-image.png" alt="Upload" />
+                                        <input id="expansion-upload" type="file" accept="image/*" /></label>
+                                </div>
+                            </td>
                         </tr>
                         <tr>
-                            <td><label for="picture-zoom">Zoom:</label></td>
-                            <td colspan="2"><input id="picture-zoom" type="range" min="0" max="3" value="1" step="0.1"></td>
+                            <td class="hideForPileMarker hideForTrivia">
+                                <div>
+                                    <label for="credit">Art Credit</label>
+                                    <input id="credit" type="text" placeholder="Illustration: Jane Doe" />
+                                </div>
+                            </td>
                         </tr>
                         <tr>
-                            <td colspan="3"><button onclick="(function(){
-                                     document.getElementById('picture-x').value=0;
-                                     document.getElementById('picture-y').value=0;
-                                     let z = document.getElementById('picture-zoom');z.value=1;
-                                     z.onchange();})();">Reset Position</button>
+                            <td class="hideForPileMarker hideForTrivia">
+                                <div>
+                                    <label for="creator">Version &amp; Creator Credit</label>
+                                    <input id="creator" type="text" placeholder="v0.1 John Doe" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td id="priceCell" class="hideForPileMarker hideForMats hideForTrivia">
+                                <div>
+                                    <label for="price">Price</label>
+                                    <input id="price" placeholder="$3" />
+                            </td>
+                            <td id="previewCell" class="hideForPileMarker hideForMats hideForTrivia">
+                                <div>
+                                    <label for="preview"></label>
+                                    <input id="preview" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="hideForBaseCards hideForPileMarker hideForMats hideForTraits hideForTrivia">
+                                <div>
+                                    <label for="normalcolor2">Color</label>
+                                    <span id="color-switch"><button id="color-switch-button" alt="Switch Colors"><img src="assets/icon-switch.png" />Switch</button></span>
+                                    <select name="normalcolor" id="normalcolor2">
+                                        <option>SAME</option>
+                                    </select>
+                                    <div style="display:none;" title="Card color">
+                                        <input type="number" name="recolor" min="0" max="10" step=".05" value="0.75" /><input type="number" name="recolor" min="0" max="10" step=".05" value="1.1" /><input type="number" name="recolor" min="0" max="10" step=".05" value="1.35" />
+                                    </div>
+                                    <div style="display:none;" title="Card fade color">
+                                        <input type="number" name="recolor" min="0" max="10" step=".05" value="0" /><input type="number" name="recolor" min="0" max="10" step=".05" value="0" /><input type="number" name="recolor" min="0" max="10" step=".05" value="0" />
+                                    </div>
+                                    <div id="color2splitselector" class="hideForLandscape" style="display:none;">
+                                        <label for="color2split">Split Position</label>
+                                        <select name="color2split" id="color2split">
+                                            <option value="18">Smaller Top</option>
+                                            <option value="1" selected="selected">Half</option>
+                                            <option value="19">Smaller Bottom</option>
+                                            <option value="12">Blend Night</option>
+                                            <option value="27">Half Action</option>
+                                        </select>
+                                    </div>
+                                </div>
                             </td>
                         </tr>
                     </table>
-                </div>
-            </td>
-            <td class="hideForPileMarker hideForTrivia">
-                <div>
-                    <label for="expansion">URL of Expansion Icon</label>
-                    <input id="expansion" type="url" placeholder="http://example.com/expansion.png" />
-                    <label class="image-upload" title="Use Local Image File"><img src="assets/icon-upload-image.png" alt="Upload" />
-                        <input id="expansion-upload" type="file" accept="image/*" /></label>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td class="hideForPileMarker hideForTrivia">
-                <div>
-                    <label for="credit">Art Credit</label>
-                    <input id="credit" type="text" placeholder="Illustration: Jane Doe" />
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td class="hideForPileMarker hideForTrivia">
-                <div>
-                    <label for="creator">Version &amp; Creator Credit</label>
-                    <input id="creator" type="text" placeholder="v0.1 John Doe" />
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td id="priceCell" class="hideForPileMarker hideForMats hideForTrivia">
-                <div>
-                    <label for="price">Price</label>
-                    <input id="price" placeholder="$3" />
-            </td>
-            <td id="previewCell" class="hideForPileMarker hideForMats hideForTrivia">
-                <div>
-                    <label for="preview"></label>
-                    <input id="preview" />
-                </div>
+                </details>
             </td>
         </tr>
         <tr>
@@ -303,31 +339,6 @@
                         <div title="Card fade color"><input type="number" name="recolor" min="0" max="10" step=".05" value="0" /><input type="number" name="recolor" min="0" max="10" step=".05" value="0" /><input type="number" name="recolor" min="0" max="10" step=".05" value="0" /></div>
                         <div title="Accent color 1"><input type="number" name="recolor" min="0" max="10" step=".05" value="1" /><input type="number" name="recolor" min="0" max="10" step=".05" value="2" /><input type="number" name="recolor" min="0" max="10" step=".05" value="3" /></div>
                         <div title="Accent color 2"><input type="number" name="recolor" min="0" max="10" step=".05" value="4" /><input type="number" name="recolor" min="0" max="10" step=".05" value="5" /><input type="number" name="recolor" min="0" max="10" step=".05" value="6" /></div>
-                    </div>
-                </div>
-            </td>
-            <td class="hideForBaseCards hideForPileMarker hideForMats hideForTraits hideForTrivia">
-                <div>
-                    <label for="normalcolor2">Color</label>
-                    <span id="color-switch"><button id="color-switch-button" alt="Switch Colors"><img src="assets/icon-switch.png" />Switch</button></span>
-                    <select name="normalcolor" id="normalcolor2">
-                        <option>SAME</option>
-                    </select>
-                    <div style="display:none;" title="Card color">
-                        <input type="number" name="recolor" min="0" max="10" step=".05" value="0.75" /><input type="number" name="recolor" min="0" max="10" step=".05" value="1.1" /><input type="number" name="recolor" min="0" max="10" step=".05" value="1.35" />
-                    </div>
-                    <div style="display:none;" title="Card fade color">
-                        <input type="number" name="recolor" min="0" max="10" step=".05" value="0" /><input type="number" name="recolor" min="0" max="10" step=".05" value="0" /><input type="number" name="recolor" min="0" max="10" step=".05" value="0" />
-                    </div>
-                    <div id="color2splitselector" class="hideForLandscape" style="display:none;">
-                        <label for="color2split">Split Position</label>
-                        <select name="color2split" id="color2split">
-                            <option value="18">Smaller Top</option>
-                            <option value="1" selected="selected">Half</option>
-                            <option value="19">Smaller Bottom</option>
-                            <option value="12">Blend Night</option>
-                            <option value="27">Half Action</option>
-                        </select>
                     </div>
                 </div>
             </td>


### PR DESCRIPTION
## Summary
- place advanced card options inside new `<details>` dropdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d845a6bfc8320a804a3ef677b29de