### PR TITLE
Add inline icons to text fields

### DIFF
--- a/docs/favorites.html
+++ b/docs/favorites.html
@@ -56,6 +56,7 @@
         window.addEventListener('DOMContentLoaded', () => {
             myFavorites = new Favorites('myFavorites');
             myFavorites.refresh();
+            setupIconInputs();
         });
     </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,6 +44,7 @@
             initCardImageGenerator();
             myFontSettings = new FontHandler();
             myFavorites = new Favorites( 'myFavorites' );
+            setupIconInputs();
         }
         
         window.addEventListener("load", function(event) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -882,3 +882,29 @@ body.favorites-page #favorites-list {
     width: 100%;
     box-sizing: border-box;
 }
+
+.icon-wrapper {
+    position: relative;
+}
+.icon-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    white-space: pre-wrap;
+    font: inherit;
+    color: var(--color-input-text);
+    overflow: hidden;
+    padding: inherit;
+}
+.iconized {
+    color: transparent;
+    caret-color: var(--color-input-text);
+}
+.inline-icon {
+    height: 1em;
+    vertical-align: bottom;
+    pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- expose icon map globally for UI use
- display special icons inside inputs using overlays
- update CSS for icon overlays
- initialize icon overlays on the card generator and favorites page
- refresh favorites table to show icons after each rebuild

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687da054ea088320a15584b236a54cf4