### PR TITLE
Fix icon overlay misalignment

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1099,6 +1099,9 @@ function initCardImageGenerator() {
         var end = active.selectionEnd;
         active.setRangeText(text, start, end, 'end');
         queueDraw(1);
+        // Manually trigger an input event so any overlays update immediately
+        var ev = new Event('input', { bubbles: true });
+        active.dispatchEvent(ev);
     }
 
     var legend = document.getElementById("legend");

--- a/docs/style.css
+++ b/docs/style.css
@@ -905,6 +905,8 @@ body.favorites-page #favorites-list {
 }
 .inline-icon {
     height: 1em;
+    width: 1em;
     vertical-align: bottom;
     pointer-events: none;
+    object-fit: contain;
 }


### PR DESCRIPTION
## Summary
- trigger input events when inserting icons so overlays update immediately
- size inline icon images to 1em so text cursor remains in sync

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dbb2ca424832096b6aff848f92089