### PR TITLE
Fix caret offset for iconized inputs

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1887,7 +1887,8 @@ function textToIconHTML(text) {
     return Array.from(text).map(ch => {
         if (window.ICON_MAP[ch]) {
             const src = 'card-resources/' + window.ICON_MAP[ch][0] + '.png';
-            return '<img class="inline-icon" src="' + src + '" alt="' + ch + '" />';
+            return '<span class="inline-icon" style="--icon:url(' + "'" + src + "'" + ')">' +
+                ch.replace(/[&<>]/g, c => escape[c] || c) + '</span>';
         }
         return ch.replace(/[&<>]/g, c => escape[c] || c);
     }).join('');

--- a/docs/style.css
+++ b/docs/style.css
@@ -904,9 +904,20 @@ body.favorites-page #favorites-list {
     caret-color: var(--color-input-text);
 }
 .inline-icon {
-    height: 1em;
-    width: 1em;
-    vertical-align: bottom;
+    position: relative;
+    color: transparent;
     pointer-events: none;
-    object-fit: contain;
+}
+.inline-icon::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: var(--icon);
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- show icons in inputs using CSS pseudo-elements so text width isn't affected
- keep the text character in place to align the caret correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dc211ce40832094016a58fdc46825