### PR TITLE
Fix iconized text input overlay

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -895,9 +895,11 @@ body.favorites-page #favorites-list {
     pointer-events: none;
     white-space: pre-wrap;
     font: inherit;
+    line-height: inherit;
     color: var(--color-input-text);
     overflow: hidden;
     padding: inherit;
+    box-sizing: border-box;
 }
 .iconized {
     color: transparent;
@@ -906,6 +908,7 @@ body.favorites-page #favorites-list {
 .inline-icon {
     position: relative;
     color: transparent;
+    line-height: inherit;
     pointer-events: none;
 }
 .inline-icon::after {


### PR DESCRIPTION
## Summary
- ensure overlay icons mirror text line height
- account for padding in overlays so cursor positions match

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687dc48f18c08320979d4ee911578a83