### PR TITLE
Fix icon overlay alignment for text inputs

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1915,6 +1915,14 @@ function setupIconInputs(root) {
         overlay.setAttribute('contenteditable', 'false');
         wrapper.appendChild(overlay);
 
+        // copy font and padding from the input so the overlay text aligns with
+        // the caret.  This keeps the displayed icon text in sync with the
+        // underlying input metrics.
+        const styles = window.getComputedStyle(el);
+        overlay.style.padding = styles.padding;
+        overlay.style.font = styles.font;
+        overlay.style.lineHeight = styles.lineHeight;
+
         function update() {
             const value = el.value !== undefined ? el.value : el.textContent;
             overlay.innerHTML = textToIconHTML(value);


### PR DESCRIPTION
## Summary
- ensure the overlay for iconized text inputs copies padding and font from the underlying element so text aligns with the caret

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e4579dd4c83209a5f7e5ca2c4b6f4