### PR TITLE
Enable automatic mobile page redirect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,16 @@
     <meta name="msapplication-config" content="./favicon/browserconfig.xml">
     <meta name="theme-color" content="#B4B39A">
     <meta name="color-scheme" content="light dark">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <script>
+        // Redirect to the mobile friendly page when accessed from a mobile device
+        if (/Mobi|Android/i.test(navigator.userAgent) && !location.pathname.endsWith('mobile.html')) {
+            const url = new URL(location.href);
+            url.pathname = url.pathname.replace(/[^\/]*$/, 'mobile.html');
+            location.replace(url.toString());
+        }
+    </script>
 
     <script>
         function setThemeColor(e) {

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -15,6 +15,7 @@
     <meta name="msapplication-config" content="./favicon/browserconfig.xml">
     <meta name="theme-color" content="#B4B39A">
     <meta name="color-scheme" content="light dark">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <script>
         function setThemeColor(e) {


### PR DESCRIPTION
## Summary
- add viewport meta for responsive scaling
- redirect to `mobile.html` when site is visited from a mobile device
- ensure `mobile.html` also uses viewport meta

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e463d3c388320b0159bf3a8a46b7e