### PR TITLE
Display icons inside text fields

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,6 +44,7 @@
             initCardImageGenerator();
             myFontSettings = new FontHandler();
             myFavorites = new Favorites( 'myFavorites' );
+            setupIconInputs();
         }
         
         window.addEventListener("load", function(event) {

--- a/docs/main.js
+++ b/docs/main.js
@@ -5,6 +5,67 @@ let useCORS = true; // flag to activate loading of external images via CORS help
 //const CORS_ANYWHERE_BASE_URL = 'https://thingproxy.freeboard.io/fetch/';
 const CORS_ANYWHERE_BASE_URL = 'https://proxy.cors.sh/'; // from https://blog.grida.co/cors-anywhere-for-everyone-free-reliable-cors-proxy-service-73507192714e
 
+const ICON_MAP = {
+    "@": "Debt",
+    "^": "Potion",
+    "%": "HP",
+    "#": "HP-Token",
+    "~": "heart",
+    "&": "food",
+    "$": "Coin",
+    "*": "Sun",
+    "§": "Custom Icon"
+};
+
+function iconify(text) {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/([@^%#~&$*§])/g, c => `<img class="icon-inline" src="card-resources/${ICON_MAP[c]}.png" data-icon="${c}" alt="${c}">`)
+        .replace(/\n/g, '<br>');
+}
+
+function setupIconOverlay(elem) {
+    if (!elem) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'icon-wrapper';
+    elem.parentNode.insertBefore(wrapper, elem);
+    wrapper.appendChild(elem);
+    const overlay = document.createElement('div');
+    overlay.className = 'icon-overlay';
+    wrapper.appendChild(overlay);
+    elem.classList.add('icon-text');
+    function update() { overlay.innerHTML = iconify(elem.value); }
+    update();
+    elem.addEventListener('input', update);
+}
+
+function setupIconOverlayEditable(elem) {
+    if (!elem) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'icon-wrapper';
+    elem.parentNode.insertBefore(wrapper, elem);
+    wrapper.appendChild(elem);
+    const overlay = document.createElement('div');
+    overlay.className = 'icon-overlay';
+    wrapper.appendChild(overlay);
+    elem.classList.add('icon-text');
+    function update() { overlay.innerHTML = iconify(elem.textContent); }
+    update();
+    elem.addEventListener('input', update);
+}
+
+function setupIconInputs() {
+    [
+        'title','title2','description','description2',
+        'type','type2','price','preview','boldkeys'
+    ].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) setupIconOverlay(el);
+    });
+}
+
 Array.prototype.remove = function () {
     var what, a = arguments,
         L = a.length,
@@ -1714,6 +1775,7 @@ function Favorites(name) {
                 let td = document.createElement('td');
                 td.contentEditable = 'true';
                 td.textContent = item[key];
+                setupIconOverlayEditable(td);
                 td.addEventListener('blur', () => {
                     item[key] = td.textContent.trim();
                     saveChanges();

--- a/docs/style.css
+++ b/docs/style.css
@@ -882,3 +882,33 @@ body.favorites-page #favorites-list {
     width: 100%;
     box-sizing: border-box;
 }
+
+/* display icons inside text fields */
+.icon-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.icon-wrapper .icon-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    white-space: pre-wrap;
+}
+
+.icon-text {
+    color: transparent;
+    text-shadow: 0 0 0 var(--color-input-text);
+    caret-color: var(--color-input-text);
+}
+.icon-text::placeholder {
+    color: var(--color-input-text);
+}
+
+.icon-inline {
+    height: 1em;
+    vertical-align: -0.2em;
+}


### PR DESCRIPTION
## Summary
- overlay text fields with icon images
- add CSS helpers for overlays
- convert favorites table cells to use icon overlays

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687da054ea088320a15584b236a54cf4