### PR TITLE
Add iframe-based card preview

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,12 @@
     <meta name="color-scheme" content="light dark">
 
     <script>
+        if(/Mobi|Android/i.test(navigator.userAgent)){
+            window.location.href = 'mobile.html';
+        }
+    </script>
+
+    <script>
         function setThemeColor(e) {
             if (e.matches) {
                 document.head.querySelector("[name=theme-color][content]").setAttribute("content", "#000000");

--- a/docs/mobile.css
+++ b/docs/mobile.css
@@ -1,0 +1,8 @@
+body,html{margin:0;padding:0;font-family:sans-serif;background:#fafafa;color:#000}
+.page{padding:1em}
+.card{width:100%;max-width:400px;height:220px;margin:1em auto;border:none}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:1em;margin-top:1em}
+.grid button,.buttons button{padding:1em;font-size:1em;width:100%}
+.field{margin-top:1em}
+.field input{width:100%;padding:0.5em;font-size:1em;border-radius:5px;border:1px solid #ccc}
+.buttons{display:flex;gap:1em;margin-top:1em;justify-content:center}

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Mobile Card Maker</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link rel="stylesheet" href="mobile.css" />
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js');
+        }
+    </script>
+</head>
+<body>
+<div id="app"></div>
+<script src="mobile.js"></script>
+</body>
+</html>

--- a/docs/mobile.js
+++ b/docs/mobile.js
@@ -1,0 +1,54 @@
+(function(){
+const app=document.getElementById('app');
+const state={type:'',title:'',description:'',price:'',preview:'',colorIndex:0};
+const colorIndices={Trivia:0,Creature:4,Friend:4,Opponent:10,Treasure:1,Other:0};
+function isMobile(){return /Mobi|Android/i.test(navigator.userAgent);}
+function buildCardURL(){
+ const params=new URLSearchParams();
+ params.set('type',state.type);
+ params.set('size',state.type==='Trivia'?6:0);
+ params.set('color0',state.colorIndex);
+ if(state.title)params.set('title',state.title);
+ if(state.description)params.set('description',state.description);
+ if(state.price)params.set('price',state.price);
+ if(state.preview)params.set('preview',state.preview);
+ params.set('view','card');
+ return 'index.html?'+params.toString();
+}
+function saveFavorite(){
+ const params=new URLSearchParams();
+ params.set('type',state.type);
+ params.set('size',state.type==='Trivia'?6:0);
+ params.set('color0',state.colorIndex);
+ if(state.title)params.set('title',state.title);
+ if(state.description)params.set('description',state.description);
+ if(state.price)params.set('price',state.price);
+ if(state.preview)params.set('preview',state.preview);
+ const qs='?'+params.toString();
+ let data=localStorage.getItem('favorites');
+ let arr=data?JSON.parse(data):[];
+ arr.push(qs);
+ localStorage.setItem('favorites',JSON.stringify(arr));
+ showStep1();
+}
+function focusAndScroll(el){setTimeout(()=>{el.focus();el.scrollIntoView({behavior:'smooth',block:'center'});},50);}
+function showCard(){
+  return `<iframe class="card" id="card" src="${buildCardURL()}"></iframe>`;
+}
+function showStep1(){app.innerHTML=`<div class="page"><h2>What type of card would you like to make?</h2><div class="grid">
+<button data-t='Trivia'>Trivia</button>
+<button data-t='Creature'>Creature</button>
+<button data-t='Friend'>Friend</button>
+<button data-t='Opponent'>Opponent</button>
+<button data-t='Treasure'>Treasure</button>
+<button data-t='Other'>Other</button>
+</div></div>`;
+app.querySelectorAll('button').forEach(b=>b.addEventListener('click',()=>{
+ state.type=b.dataset.t;state.colorIndex=colorIndices[state.type]||0;state.title='';state.description='';state.price='';state.preview='';showStep2();
+}));}
+function showStep2(){app.innerHTML=`${showCard()}<div class="page"><div class="field"><input id="titleInput" placeholder="${state.type==='Trivia'?'Question':'Title'}" value="${state.title||''}"/></div><div class="buttons"><button id="back">Back</button><button id="next">Next</button></div></div>`;document.getElementById('back').onclick=showStep1;document.getElementById('next').onclick=()=>{state.title=document.getElementById('titleInput').value;showStep3();};focusAndScroll(document.getElementById('titleInput'));}
+function showStep3(){app.innerHTML=`${showCard()}<div class="page"><div class="field"><input id="descInput" placeholder="${state.type==='Trivia'?'Answer':'Description'}" value="${state.description||''}"/></div><div class="buttons"><button id="back">Back</button><button id="next">Next</button><button id="save">Save</button></div></div>`;document.getElementById('back').onclick=showStep1;document.getElementById('next').onclick=()=>{state.description=document.getElementById('descInput').value;if(state.type==='Trivia'){showStep5();}else{showStep4();}};document.getElementById('save').onclick=()=>{state.description=document.getElementById('descInput').value;saveFavorite();};focusAndScroll(document.getElementById('descInput'));}
+function showStep4(){if(state.type==='Trivia'){showStep5();return;}let nextBtn=(state.type==='Treasure'||state.type==='Opponent')?`<button id="next">Next</button>`:'';app.innerHTML=`${showCard()}<div class="page"><div class="field"><input id="priceInput" placeholder="Price" value="${state.price||''}"/></div><div class="buttons"><button id="back">Back</button>${nextBtn}<button id="save">Save</button></div></div>`;document.getElementById('back').onclick=showStep3;const next=document.getElementById('next');if(next)next.onclick=()=>{state.price=document.getElementById('priceInput').value;showStep5();};document.getElementById('save').onclick=()=>{state.price=document.getElementById('priceInput').value;saveFavorite();};focusAndScroll(document.getElementById('priceInput'));}
+function showStep5(){let symbol='$';let label='value';if(state.type==='Opponent'){symbol='%';label='Defeated value';}else if(state.type==='Trivia'){symbol='*';label='Difficulty';}app.innerHTML=`${showCard()}<div class="page"><div class="field"><input id="prevInput" placeholder="${label}" value="${state.preview||symbol}"/></div><div class="buttons"><button id="back">Back</button><button id="save">Save</button></div></div>`;document.getElementById('back').onclick=()=>{if(state.type==='Trivia'){showStep3();}else{showStep4();}};document.getElementById('save').onclick=()=>{state.preview=document.getElementById('prevInput').value;saveFavorite();};const inp=document.getElementById('prevInput');if(state.preview===''){inp.value=symbol;}focusAndScroll(inp);} 
+window.addEventListener('DOMContentLoaded',()=>{if(!isMobile()){window.location.href='index.html';return;}showStep1();});
+})();


### PR DESCRIPTION
## Summary
- update mobile workflow to show rendered card via generator
- map template types to primary color index
- improve mobile stylesheet for new preview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e5813087c83208ad9cba69ef8b443