### PR TITLE
Fix card iframe width on mobile view

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -836,6 +836,12 @@ html.view-card #table td {
 html.view-card body {
     margin: 0;
     background: white;
+    overflow-x: hidden;
+}
+
+html.view-card #table {
+    width: 100%;
+    margin: 0;
 }
 
 /* Layout adjustments for standalone favorites page */


### PR DESCRIPTION
## Summary
- remove margin on card page and prevent horizontal overflow
- ensure full width table for card-only view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e6e53ceac8320ba6a8a30b266bd5c