### PR TITLE
Fix mobile card iframe sizing

### DIFF
--- a/docs/mobile.js
+++ b/docs/mobile.js
@@ -46,8 +46,9 @@
         const f=document.createElement('iframe');
         f.id='card-frame';
         f.style.width='100%';
-        f.style.height='250px';
+        f.style.height='100vh';
         f.style.border='none';
+        f.style.display='block';
         return f;
     }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -812,7 +812,7 @@ button.delete-all:focus {
 
 #card-frame {
     width: 100%;
-    height: 1200px;
+    height: 100vh;
     border: none;
 }
 html.view-card body:before,
@@ -836,12 +836,15 @@ html.view-card #table td {
 html.view-card body {
     margin: 0;
     background: white;
-    overflow-x: hidden;
+    overflow: hidden;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
 }
 
 html.view-card #table {
-    width: 100%;
-    margin: 0;
+    width: auto;
+    margin: auto;
 }
 
 /* Layout adjustments for standalone favorites page */
@@ -907,7 +910,7 @@ body.favorites-page #favorites-list {
 }
 #wizard iframe {
     width: 100%;
-    height: 250px;
+    height: 100vh;
     border: none;
     margin-bottom: 0.5em;
 }


### PR DESCRIPTION
## Summary
- prevent iframe scrollbars and center card in `view=card` mode
- expand card iframe height on wizard and trivia pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f15545b788320ad81ef7b60d46d67