### PR TITLE
Enable multiline description input on mobile

### DIFF
--- a/docs/mobile.js
+++ b/docs/mobile.js
@@ -130,8 +130,8 @@
         updateFrame();
         const label=document.createElement('p');
         label.textContent= card.type==='Trivia' ? 'Answer' : 'Description';
-        const inp=document.createElement('input');
-        inp.type='text';
+        const inp=document.createElement('textarea');
+        inp.rows=5;
         inp.value=card.description||'';
         inp.addEventListener('input',()=>{card.description=inp.value;updateFrame();});
         wizard.appendChild(label);


### PR DESCRIPTION
## Summary
- use a `<textarea>` for the description/answer step in the mobile generator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688037cee4488320b739185f2807ea74