### PR TITLE
Enable multiline description in mobile wizard

### DIFF
--- a/docs/mobile.js
+++ b/docs/mobile.js
@@ -130,8 +130,8 @@
         updateFrame();
         const label=document.createElement('p');
         label.textContent= card.type==='Trivia' ? 'Answer' : 'Description';
-        const inp=document.createElement('input');
-        inp.type='text';
+        const inp=document.createElement('textarea');
+        inp.rows=4;
         inp.value=card.description||'';
         inp.addEventListener('input',()=>{card.description=inp.value;updateFrame();});
         wizard.appendChild(label);

--- a/docs/style.css
+++ b/docs/style.css
@@ -915,6 +915,12 @@ body.favorites-page #favorites-list {
     font-size: 1.2em;
     box-sizing: border-box;
 }
+#wizard textarea {
+    width: 100%;
+    padding: 0.6em;
+    font-size: 1.2em;
+    box-sizing: border-box;
+}
 #wizard .buttons {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- allow multi-line text entry for description/answer in the mobile wizard by using a `<textarea>`
- add styling for wizard textareas

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688037cee4488320b739185f2807ea74