### PR TITLE
Add mobile trivia page with side menu

### DIFF
--- a/docs/menu.js
+++ b/docs/menu.js
@@ -1,0 +1,12 @@
+(function(){
+    const hamburger = document.getElementById('hamburger');
+    const menu = document.getElementById('side-menu');
+    if(hamburger && menu){
+        hamburger.addEventListener('click', () => {
+            menu.classList.toggle('open');
+        });
+        menu.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', () => menu.classList.remove('open'));
+        });
+    }
+})();

--- a/docs/style.css
+++ b/docs/style.css
@@ -927,3 +927,45 @@ body.favorites-page #favorites-list {
     gap: 0.5em;
     margin-top: 0.5em;
 }
+
+/* Mobile side menu */
+#hamburger {
+    position: fixed;
+    top: 0.5em;
+    left: 0.5em;
+    z-index: 200;
+    background: var(--color-background2);
+    color: var(--color-text);
+    border: none;
+    padding: 0.3em 0.5em;
+    font-size: 1.5em;
+}
+
+#side-menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 200px;
+    background: var(--color-background2);
+    padding-top: 2.5em;
+    transform: translateX(-200px);
+    transition: transform 0.3s ease;
+    box-shadow: 2px 0 5px var(--color-shadow1-transparent);
+    z-index: 150;
+}
+
+#side-menu.open {
+    transform: translateX(0);
+}
+
+#side-menu a {
+    display: block;
+    padding: 1em;
+    text-decoration: none;
+    color: var(--color-link);
+}
+
+#side-menu a:hover {
+    background: var(--color-background3);
+}

--- a/docs/trivia-mobile.html
+++ b/docs/trivia-mobile.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Mobile Card Maker</title>
+    <title>Mobile Trivia</title>
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" type="text/css" href="fonts/font-title.css">
     <link rel="stylesheet" type="text/css" href="fonts/font-specials.css">
@@ -20,8 +20,13 @@
         <a href="mobile.html">Card Maker</a>
         <a href="trivia-mobile.html">Trivia</a>
     </nav>
-    <div id="wizard"></div>
-    <script src="mobile.js"></script>
+    <main id="trivia-container">
+        <button id="next-card">Get Trivia Card</button>
+        <button id="edit-card" class="hidden">Edit Card</button>
+        <p id="message"></p>
+        <iframe id="card-frame" title="Trivia Card"></iframe>
+    </main>
+    <script src="trivia.js"></script>
     <script src="menu.js"></script>
 </body>
 </html>

--- a/docs/trivia.html
+++ b/docs/trivia.html
@@ -3,7 +3,14 @@
 <head>
     <title>Harry Potter Trivia</title>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="style.css">
+    <script>
+        const urlParams = new URLSearchParams(window.location.search);
+        if (/Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) && !urlParams.get('view')) {
+            window.location.href = 'trivia-mobile.html';
+        }
+    </script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('sw.js');


### PR DESCRIPTION
## Summary
- create `trivia-mobile.html` themed like the mobile card maker
- add a reusable hamburger menu script
- include the side menu on the mobile card maker
- style the hamburger menu and side drawer
- redirect mobile users of `trivia.html` to the new mobile page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68804ba037308320a8a26eee7779a040