### PR TITLE
Enable editing of trivia cards in mobile wizard

### DIFF
--- a/docs/mobile.js
+++ b/docs/mobile.js
@@ -13,6 +13,8 @@
     let card = {};
     let steps = [];
     let current = 0;
+    let editing = false;
+    let originalQuery = '';
 
     function buildQuery(params){
         return '?' + Object.keys(params).map(k=>encodeURIComponent(k)+'='+encodeURIComponent(params[k])).join('&');
@@ -197,11 +199,41 @@
         });
         let data = localStorage.getItem('favorites');
         let favs = data? JSON.parse(data):[];
-        favs = favs.filter(f => (getQueryParams(f).title||'') !== (card.title||''));
+        if(editing){
+            if(confirm('Overwrite the previous card? Click Cancel to save as new.')){
+                favs = favs.filter(f => f !== ('?' + originalQuery) && f !== originalQuery);
+            }
+        } else {
+            favs = favs.filter(f => (getQueryParams(f).title||'') !== (card.title||''));
+        }
         favs.push(params);
         localStorage.setItem('favorites', JSON.stringify(favs));
         resetWizard();
     }
 
-    showTypePicker();
+    function init(){
+        const params = getQueryParams(window.location.search);
+        if(params.edit !== undefined){
+            editing = true;
+            delete params.edit;
+            originalQuery = Object.keys(params).length ? buildQuery(params).substring(1) : '';
+            card = {
+                title:params.title||'',
+                description:params.description||'',
+                price:params.price||'',
+                preview:params.preview||'',
+                type:params.type||'',
+                color:params.color0
+            };
+            steps=[showTitle, showDescription];
+            if(card.type!=='Trivia') steps.push(showPrice);
+            if(['Treasure','Opponent','Trivia'].includes(card.type)) steps.push(showPreview);
+            current=0;
+            showTitle();
+        } else {
+            showTypePicker();
+        }
+    }
+
+    init();
 })();

--- a/docs/trivia.js
+++ b/docs/trivia.js
@@ -37,7 +37,8 @@ document.getElementById('next-card').addEventListener('click', loadCard);
 
 document.getElementById('edit-card').addEventListener('click', () => {
     if (currentCard) {
-        window.location.href = 'index.html' + currentCard;
+        const url = 'mobile.html' + currentCard + (currentCard.includes('?') ? '&' : '?') + 'edit=1';
+        window.location.href = url;
     }
 });
 


### PR DESCRIPTION
## Summary
- allow editing of trivia cards directly in the mobile card maker
- link the "Edit Card" button on the trivia page to `mobile.html`
- support loading card parameters and skipping the template chooser
- ask whether to overwrite or save as new when saving an edited card

## Testing
- `node -c docs/mobile.js`
- `node -c docs/trivia.js`


------
https://chatgpt.com/codex/tasks/task_e_6880fef7ea5083209988ae78d1ee0075