### PR TITLE
Add mobile-friendly favorites page

### DIFF
--- a/docs/favorites-mobile.html
+++ b/docs/favorites-mobile.html
@@ -1,0 +1,67 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Mobile Favorites</title>
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js');
+        }
+    </script>
+</head>
+<body class="favorites-page">
+    <button id="hamburger">&#9776;</button>
+    <nav id="side-menu">
+        <a href="mobile.html">Card Maker</a>
+        <a href="trivia-mobile.html">Trivia</a>
+        <a href="favorites-mobile.html">Favorites</a>
+    </nav>
+    <div id="manage-favorites">
+        <div class="menu">
+            <button type="button" class="delete-all hidden" onclick="myFavorites.deleteAll()"><img src="assets/icon-delete.png" />Delete All</button>
+            <button type="button" onclick="myFavorites.export()" title="Export"><img alt="Export" src="assets/icon-download.png" /></button>
+            <button type="button" onclick="myFavorites.import()" title="Import JSON or CSV"><img alt="Import" src="assets/icon-upload.png" /></button>
+        </div>
+        <div class="mobile-table-wrapper">
+            <table id="favorites-table" class="popup-content">
+                <thead>
+                    <tr>
+                        <th data-col="title">Title</th>
+                        <th data-col="type">Type(s)</th>
+                        <th data-col="price">Price</th>
+                        <th data-col="description">Description</th>
+                        <th data-col="preview">Preview</th>
+                        <th data-col="type2">Secondary Type</th>
+                        <th data-col="version">Version #</th>
+                        <th></th>
+                        <th></th>
+                    </tr>
+                    <tr class="filters">
+                        <th><input data-filter="title" type="search" /></th>
+                        <th><input data-filter="type" type="search" /></th>
+                        <th><input data-filter="price" type="search" /></th>
+                        <th><input data-filter="description" type="search" /></th>
+                        <th><input data-filter="preview" type="search" /></th>
+                        <th><input data-filter="type2" type="search" /></th>
+                        <th><input data-filter="version" type="search" /></th>
+                        <th></th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
+    <script src="main.js"></script>
+    <script src="menu.js"></script>
+    <script>
+        let myFavorites;
+        window.addEventListener('DOMContentLoaded', () => {
+            myFavorites = new Favorites('myFavorites');
+            myFavorites.refresh();
+        });
+    </script>
+</body>
+</html>

--- a/docs/favorites.html
+++ b/docs/favorites.html
@@ -3,6 +3,13 @@
 <head>
     <title>Favorites</title>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script>
+        const urlParams = new URLSearchParams(window.location.search);
+        if (/Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) && !urlParams.get('view')) {
+            window.location.href = 'favorites-mobile.html';
+        }
+    </script>
     <link rel="stylesheet" type="text/css" href="style.css">
     <script>
         if ('serviceWorker' in navigator) {

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -19,6 +19,7 @@
     <nav id="side-menu">
         <a href="mobile.html">Card Maker</a>
         <a href="trivia-mobile.html">Trivia</a>
+        <a href="favorites-mobile.html">Favorites</a>
     </nav>
     <div id="wizard"></div>
     <script src="mobile.js"></script>

--- a/docs/style.css
+++ b/docs/style.css
@@ -870,6 +870,7 @@ body.favorites-page #favorites-list {
     width: 100%;
     border-collapse: collapse;
     margin-top: 1em;
+    min-width: 800px;
 }
 
 #favorites-table th,
@@ -886,6 +887,10 @@ body.favorites-page #favorites-list {
 #favorites-table .filters input {
     width: 100%;
     box-sizing: border-box;
+}
+
+.mobile-table-wrapper {
+    overflow-x: auto;
 }
 
 /* Mobile wizard styles */

--- a/docs/trivia-mobile.html
+++ b/docs/trivia-mobile.html
@@ -19,6 +19,7 @@
     <nav id="side-menu">
         <a href="mobile.html">Card Maker</a>
         <a href="trivia-mobile.html">Trivia</a>
+        <a href="favorites-mobile.html">Favorites</a>
     </nav>
     <main id="trivia-container">
         <p id="message"></p>


### PR DESCRIPTION
## Summary
- create `favorites-mobile.html` for mobile users
- redirect mobile devices to mobile favorites page
- add link to mobile favorites page in side menu
- make favorites table scrollable on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68852acf03d08320a739d5d5dc7d0af8