### PR TITLE
Improve mobile favorite card editing

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1729,7 +1729,9 @@ function Favorites(name) {
             let tdEdit = document.createElement('td');
             let bttnEdit = document.createElement('button');
             bttnEdit.setAttribute('class','edit');
-            bttnEdit.onclick = () => { window.location.href = 'index.html' + item.raw; };
+            bttnEdit.onclick = () => {
+                window.location.href = 'mobile.html' + item.raw + '&edit';
+            };
             bttnEdit.appendChild(document.createTextNode('Edit'));
             tdEdit.appendChild(bttnEdit);
             tr.appendChild(tdEdit);

--- a/docs/mobile.js
+++ b/docs/mobile.js
@@ -233,11 +233,15 @@
                 type:params.type||'',
                 color:params.color0
             };
-            steps=[showTitle, showDescription];
-            if(card.type!=='Trivia') steps.push(showPrice);
-            if(['Treasure','Opponent','Trivia'].includes(card.type)) steps.push(showPreview);
-            current=0;
-            showTitle();
+            if(templates[card.type]){
+                steps=[showTitle, showDescription];
+                if(card.type!=='Trivia') steps.push(showPrice);
+                if(['Treasure','Opponent','Trivia'].includes(card.type)) steps.push(showPreview);
+                current=0;
+                showTitle();
+            } else {
+                showTypePicker();
+            }
         } else {
             showTypePicker();
         }


### PR DESCRIPTION
## Summary
- make the Favorites edit button open the mobile card editor with edit mode
- only skip the type picker if the card type is recognized

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68855eab7c508320af5d5795f7129110