### PR TITLE
Fix favorites edit to open correct card editor

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1730,7 +1730,8 @@ function Favorites(name) {
             let bttnEdit = document.createElement('button');
             bttnEdit.setAttribute('class','edit');
             bttnEdit.onclick = () => {
-                window.location.href = 'mobile.html' + item.raw + '&edit';
+                const editor = window.location.pathname.includes('favorites-mobile') ? 'mobile.html' : 'index.html';
+                window.location.href = editor + item.raw + '&edit';
             };
             bttnEdit.appendChild(document.createTextNode('Edit'));
             tdEdit.appendChild(bttnEdit);


### PR DESCRIPTION
## Summary
- Ensure favorites edit button opens mobile or desktop editor based on current workflow

## Testing
- `node --check docs/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1dabd9c288320b8bc62cb3a4b4fa0