### PR TITLE
Fix export button overlap on favorites page

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -862,6 +862,11 @@ body.favorites-page #manage-favorites .menu {
     background: var(--color-background2);
 }
 
+#hamburger ~ #manage-favorites .menu {
+    /* Make room for the fixed hamburger menu button */
+    padding-left: 3.5em;
+}
+
 body.favorites-page #favorites-list {
     margin-top: 1em;
 }


### PR DESCRIPTION
## Summary
- keep favorites export controls from hiding under the hamburger menu on mobile

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dbba8d588320870ee08dce59b63f