### PR TITLE
Reset editing flag after leaving mobile card editor

### DIFF
--- a/docs/mobile.js
+++ b/docs/mobile.js
@@ -115,6 +115,8 @@
         card={};
         steps=[];
         current=0;
+        editing=false;
+        originalQuery='';
         showTypePicker();
     }
 


### PR DESCRIPTION
## Summary
- reset the wizard editing state and stored query when returning to the type picker so new cards are not treated as edits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3073092d48320b2b001826f77f990